### PR TITLE
🐞 fix(liteos): 修复缺少包含路径

### DIFF
--- a/kernel/liteos/liteos_v208.6.0_b017/CMakeLists.txt
+++ b/kernel/liteos/liteos_v208.6.0_b017/CMakeLists.txt
@@ -55,6 +55,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/Huawei_LiteOS/compat/cmsis/
 ${CMAKE_CURRENT_SOURCE_DIR}/Huawei_LiteOS/open_source/CMSIS/CMSIS/RTOS/LiteOS/INC/
 ${CMAKE_CURRENT_SOURCE_DIR}/Huawei_LiteOS/open_source/CMSIS/Core/Include
 ${CMAKE_CURRENT_SOURCE_DIR}/Huawei_LiteOS/open_source/CMSIS/CMSIS/RTOS2/Include
+${CMAKE_CURRENT_SOURCE_DIR}/Huawei_LiteOS/targets/aiot/${LITEOS_PLATFORM}/include
 )
 
 target_include_directories(${COMPONENT_NAME}_interface


### PR DESCRIPTION
cjson中`#include <limits.h>`最终调用到了liteos内部的头文件，但是sdk默认未包含该路径，导致编译错误。

![1731055075589](https://github.com/user-attachments/assets/c25ab88b-3242-4cc0-92fe-ba8c33c9224b)
